### PR TITLE
New Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# example: docker run net-monitor 
-# example: docker run net-monitor azurecr.io
 FROM alpine
-ENTRYPOINT [ "/bin/ping", "-c", "3" ]
-CMD ["localhost"]
+ARG SLEEP="30m"
+ARG TEXT="Local net-monitor docker image text no arguments"
+RUN echo $TEXT 'now sleeping for' $SLEEP 'at:' >message.txt
+RUN echo $SLEEP >sleep.txt
+CMD cat message.txt && date && sleep $(cat sleep.txt)


### PR DESCRIPTION
Enables custom messages and timeout until the container is killed to be passed upon build time.  This enables the ability to have multiple variety of image text options for people who look at the container logs.

Signed-off-by: David Tesar <david.tesar@microsoft.com>